### PR TITLE
chore(deps): update nokogiri to 1.19.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     method_source (1.1.0)
     mini_portile2 (2.8.9)
     nenv (0.3.0)
-    nokogiri (1.18.10)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)


### PR DESCRIPTION
## Summary
- Bump nokogiri 1.18.10→1.19.3
- Resolves Dependabot update job failures where it couldn't unlock this transitive dependency

Refs unhappychoice/oss-issue-opener#160

## Test plan
- [x] `bundle check` passes