### PR TITLE
chore(deps): refresh Gemfile.lock to unblock Dependabot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parallel (1.28.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc


### PR DESCRIPTION
Bumps `parallel` in the lockfile from 1.28.0 to 2.1.0.

Dependabot was crashing with `Error processing parallel (RuntimeError)` when
refreshing existing PRs because the stale 1.x lockfile entry was failing the
resolver. rubocop 1.86.1+ already relaxed its constraint to `parallel >= 1.10`,
so this is just a lockfile refresh.

Closes unhappychoice/oss-issue-opener#197