### PR TITLE
chore(deps): refresh Gemfile.lock to unblock Dependabot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     method_source (1.1.0)
     mini_portile2 (2.8.9)
     nenv (0.3.0)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)


### PR DESCRIPTION
## Summary
- Dependabot crashed with `unknown_error` on `nokogiri` during the scheduled 2026-06-19 run, leaving the lockfile stale.
- Running `bundle update nokogiri lumberjack` locally resolves cleanly (`nokogiri` 1.19.3 → 1.19.4) which should unblock the next scheduled Dependabot run.

## Test plan
- [x] `bundle exec rspec` passes (7 examples, 0 failures)

Refs: unhappychoice/oss-issue-opener#253